### PR TITLE
Try Appveyor for unit tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Fix line endings in Windows. (runs before repo cloning)
+init:
+  - git config --global core.autocrlf true
+
+# Test against these versions of Node.js.
+environment:
+  matrix:
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node 0.STABLE.latest
+  - ps: Install-Product node 0.10.30 x86
+  # Typical npm stuff.
+  - md C:\nc
+  - npm install -g npm@^2"
+  - npm config set cache C:\nc
+  - npm version
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - npm version
+  - cmd: npm test
+
+# Don't actually build.
+build: off
+
+# Set build version format here instead of in the admin panel.
+version: "{build}"


### PR DESCRIPTION
So, I thought this would be hard, but it apparently works:

https://ci.appveyor.com/project/lmorchard/node-firefox-find-simulators

They offer build status images, too. But, it looks like the mozilla repo has to be enabled to generate the URLs with a token string included.